### PR TITLE
Add check for syfo-tilgang when checking tilgang to enhet

### DIFF
--- a/src/main/kotlin/no/nav/syfo/App.kt
+++ b/src/main/kotlin/no/nav/syfo/App.kt
@@ -14,7 +14,6 @@ import no.nav.syfo.client.graphapi.GraphApiClient
 import no.nav.syfo.client.wellknown.getWellKnown
 import no.nav.syfo.tilgang.AdRoller
 import org.slf4j.LoggerFactory
-import redis.clients.jedis.*
 import java.util.concurrent.TimeUnit
 
 const val applicationPort = 8080
@@ -37,7 +36,7 @@ fun main() {
 
     val axsysClient = AxsysClient(
         azureAdClient = azureAdClient,
-        baseUrl = environment.clients.axsys.baseUrl,
+        axsysUrl = environment.clients.axsys.baseUrl,
         clientId = environment.clients.axsys.clientId,
     )
 

--- a/src/main/kotlin/no/nav/syfo/tilgang/Tilgang.kt
+++ b/src/main/kotlin/no/nav/syfo/tilgang/Tilgang.kt
@@ -1,5 +1,8 @@
 package no.nav.syfo.tilgang
 
 data class Tilgang(
-    val harTilgang: Boolean = false
+    val erGodkjent: Boolean = false,
+    @Deprecated("Byttet navn til erGodkjent, beholdt for tilbakekompabilitet hos konsumenter")
+    val harTilgang: Boolean = erGodkjent,
+    val erAvslatt: Boolean = !erGodkjent
 )

--- a/src/main/kotlin/no/nav/syfo/tilgang/TilgangApi.kt
+++ b/src/main/kotlin/no/nav/syfo/tilgang/TilgangApi.kt
@@ -28,7 +28,7 @@ fun Route.registerTilgangApi(
                 callId = callId,
             )
 
-            if (tilgang.harTilgang) {
+            if (tilgang.erGodkjent) {
                 call.respond(tilgang)
             } else {
                 call.respond(
@@ -46,17 +46,25 @@ fun Route.registerTilgangApi(
                 throw IllegalArgumentException("Failed to check enhetstilgang for veileder. No NAV ident in token")
             }
 
-            val enhetNr = call.parameters[enhetNr]
-                ?: throw IllegalArgumentException("No EnhetNr found in path param")
+            val enhetNr = call.parameters[enhetNr] ?: throw IllegalArgumentException("No EnhetNr found in path param")
             val enhet = Enhet(enhetNr)
 
-            val tilgang = tilgangService.hasTilgangToEnhet(
+            val syfoTilgang = tilgangService.hasTilgangToSyfo(
                 token = token,
                 callId = callId,
-                enhet = enhet,
             )
 
-            if (tilgang.harTilgang) {
+            val tilgang = if (syfoTilgang.erAvslatt) {
+                syfoTilgang
+            } else {
+                tilgangService.hasTilgangToEnhet(
+                    token = token,
+                    callId = callId,
+                    enhet = enhet,
+                )
+            }
+
+            if (tilgang.erGodkjent) {
                 call.respond(tilgang)
             } else {
                 call.respond(

--- a/src/main/kotlin/no/nav/syfo/tilgang/TilgangService.kt
+++ b/src/main/kotlin/no/nav/syfo/tilgang/TilgangService.kt
@@ -23,7 +23,7 @@ class TilgangService(
         }
 
         val tilgang = Tilgang(
-            harTilgang = graphApiClient.hasAccess(
+            erGodkjent = graphApiClient.hasAccess(
                 adRolle = adRoller.SYFO,
                 token = token,
                 callId = callId,
@@ -45,10 +45,9 @@ class TilgangService(
         if (cachedTilgang != null) {
             return cachedTilgang
         }
-
         val enheter = axsysClient.getEnheter(token = token, callId = callId)
         val tilgang = Tilgang(
-            harTilgang = enheter.map { it.enhetId }.contains(enhet.id)
+            erGodkjent = enheter.map { it.enhetId }.contains(enhet.id)
         )
         redisStore.setObject(
             key = cacheKey,

--- a/src/test/kotlin/no/nav/syfo/mocks/AxsysMock.kt
+++ b/src/test/kotlin/no/nav/syfo/mocks/AxsysMock.kt
@@ -6,11 +6,16 @@ import io.ktor.client.request.*
 import io.ktor.http.*
 import no.nav.syfo.application.api.auth.JWT_CLAIM_NAVIDENT
 import no.nav.syfo.client.axsys.AxsysEnhet
+import no.nav.syfo.client.axsys.AxsysTilgangerResponse
 import no.nav.syfo.testhelper.UserConstants
 
-private val axsysEnhetResponse = AxsysEnhet(
+private val axsysEnhet = AxsysEnhet(
     enhetId = UserConstants.VEILEDER_ENHET,
     navn = "enhet",
+)
+
+private val axsysResponse = AxsysTilgangerResponse(
+    enheter = listOf(axsysEnhet)
 )
 
 fun MockRequestHandleScope.getAxsysResponse(request: HttpRequestData): HttpResponseData {
@@ -20,7 +25,7 @@ fun MockRequestHandleScope.getAxsysResponse(request: HttpRequestData): HttpRespo
     return when (veilederIdent) {
         UserConstants.VEILEDER_IDENT -> {
             respond(
-                content = mapper.writeValueAsString(listOf(axsysEnhetResponse)),
+                content = mapper.writeValueAsString(axsysResponse),
                 status = HttpStatusCode.OK,
                 headers = headersOf(HttpHeaders.ContentType, "application/json")
             )

--- a/src/test/kotlin/no/nav/syfo/testhelper/TestApiModule.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/TestApiModule.kt
@@ -30,7 +30,7 @@ fun Application.testApiModule(
 
     val axsysClient = AxsysClient(
         azureAdClient = azureAdClient,
-        baseUrl = externalMockEnvironment.environment.clients.axsys.baseUrl,
+        axsysUrl = externalMockEnvironment.environment.clients.axsys.baseUrl,
         clientId = externalMockEnvironment.environment.clients.axsys.clientId,
         httpClient = mockHttpClient,
     )

--- a/src/test/kotlin/no/nav/syfo/testhelper/UserConstants.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/UserConstants.kt
@@ -4,5 +4,5 @@ object UserConstants {
     const val VEILEDER_IDENT = "Z999999"
     const val VEILEDER_IDENT_NO_SYFO_ACCESS = "Z00000_no_syfo_access"
     const val VEILEDER_ENHET = "1234"
-    const val VEILEDER_ENHET_NO_ACCESS = "9999"
+    const val VEILEDER_NO_ACCESS_ENHET = "9999"
 }

--- a/src/test/kotlin/no/nav/syfo/tilgang/TilgangServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/tilgang/TilgangServiceSpek.kt
@@ -28,6 +28,20 @@ class TilgangServiceSpek : Spek({
 
     val TWELVE_HOURS_IN_SECONDS = 12 * 60 * 60L
 
+    fun verifyCacheSet(exactly: Int, key: String = "", harTilgang: Boolean = true) {
+        verify(exactly = exactly) {
+            if (exactly == 0) {
+                redisStore.setObject<Any>(any(), any(), any())
+            } else {
+                redisStore.setObject(
+                    key = key,
+                    value = Tilgang(erGodkjent = harTilgang),
+                    expireSeconds = TWELVE_HOURS_IN_SECONDS
+                )
+            }
+        }
+    }
+
     describe("sjekkTilgangTilTjenesten") {
         val validToken = Token(
             generateJWT(
@@ -41,8 +55,21 @@ class TilgangServiceSpek : Spek({
             clearMocks(graphApiClient, redisStore, axsysClient)
         }
 
-        describe("has access to SYFO") {
+        describe("check if veileder has access to SYFO") {
             val cacheKey = "tilgang-til-tjenesten-${UserConstants.VEILEDER_IDENT}"
+
+            it("return result from cache hit") {
+                val callId = "123"
+                every { redisStore.getObject<Tilgang?>(any()) } returns Tilgang(erGodkjent = true)
+
+                runBlocking {
+                    tilgangService.hasTilgangToSyfo(validToken, callId)
+                }
+
+                verify(exactly = 1) { redisStore.getObject<Tilgang?>(key = cacheKey) }
+                coVerify(exactly = 0) { graphApiClient.hasAccess(any(), any(), any()) }
+                verifyCacheSet(exactly = 0)
+            }
 
             it("cache response from GraphApiClient on cache miss") {
                 val callId = "123"
@@ -55,31 +82,14 @@ class TilgangServiceSpek : Spek({
 
                 verify(exactly = 1) { redisStore.getObject<Tilgang?>(key = cacheKey) }
                 coVerify(exactly = 1) { graphApiClient.hasAccess(adRoller.SYFO, validToken, callId) }
-                verify(exactly = 1) {
-                    redisStore.setObject(
-                        key = cacheKey,
-                        value = Tilgang(harTilgang = true),
-                        expireSeconds = TWELVE_HOURS_IN_SECONDS
-                    )
-                }
-            }
-
-            it("return result from cache hit") {
-                val callId = "123"
-                every { redisStore.getObject<Tilgang?>(any()) } returns Tilgang(harTilgang = true)
-
-                runBlocking {
-                    tilgangService.hasTilgangToSyfo(validToken, callId)
-                }
-
-                verify(exactly = 1) { redisStore.getObject<Tilgang?>(key = cacheKey) }
-                coVerify(exactly = 0) { graphApiClient.hasAccess(any(), any(), any()) }
-                verify(exactly = 0) { redisStore.setObject<Any>(any(), any(), any()) }
+                verifyCacheSet(exactly = 1, key = cacheKey)
             }
         }
 
-        describe("has access to enhet") {
-            it("return has access if enhet is in list from Axsys") {
+        describe("check if veileder has access to enhet") {
+            val cacheKeySyfo = "tilgang-til-tjenesten-${UserConstants.VEILEDER_IDENT}"
+
+            it("return has access if enhet is in veileders list from Axsys") {
                 val enhet = Enhet(UserConstants.VEILEDER_ENHET)
                 val veiledersEnhet = AxsysEnhet(
                     enhetId = enhet.id,
@@ -88,28 +98,23 @@ class TilgangServiceSpek : Spek({
                 val cacheKey = "tilgang-til-enhet-${UserConstants.VEILEDER_IDENT}-$enhet"
                 val callId = "123"
                 every { redisStore.getObject<Tilgang?>(any()) } returns null
-                coEvery { axsysClient.getEnheter(validToken, callId) } returns listOf(veiledersEnhet)
+                coEvery { axsysClient.getEnheter(any(), any()) } returns listOf(veiledersEnhet)
+                coEvery { graphApiClient.hasAccess(any(), any(), any()) } returns true
 
                 runBlocking {
                     val tilgang = tilgangService.hasTilgangToEnhet(validToken, callId, enhet)
 
-                    tilgang.harTilgang shouldBeEqualTo true
+                    tilgang.erGodkjent shouldBeEqualTo true
                 }
 
                 verify(exactly = 1) { redisStore.getObject<Tilgang?>(key = cacheKey) }
                 coVerify(exactly = 1) { axsysClient.getEnheter(validToken, callId) }
-                verify(exactly = 1) {
-                    redisStore.setObject(
-                        key = cacheKey,
-                        value = Tilgang(harTilgang = true),
-                        expireSeconds = TWELVE_HOURS_IN_SECONDS
-                    )
-                }
+                verifyCacheSet(exactly = 1, key = cacheKey)
             }
 
-            it("return no access if enhet is not in list from Axsys") {
+            it("return no access if enhet is not in veileders list from Axsys") {
                 val wantedEnhet = Enhet(UserConstants.VEILEDER_ENHET)
-                val actualEnhet = Enhet(UserConstants.VEILEDER_ENHET_NO_ACCESS)
+                val actualEnhet = Enhet(UserConstants.VEILEDER_NO_ACCESS_ENHET)
                 val veiledersEnhet = AxsysEnhet(
                     enhetId = actualEnhet.id,
                     navn = "enhet",
@@ -122,35 +127,30 @@ class TilgangServiceSpek : Spek({
                 runBlocking {
                     val tilgang = tilgangService.hasTilgangToEnhet(validToken, callId, wantedEnhet)
 
-                    tilgang.harTilgang shouldBeEqualTo false
+                    tilgang.erGodkjent shouldBeEqualTo false
                 }
 
                 verify(exactly = 1) { redisStore.getObject<Tilgang?>(key = cacheKey) }
                 coVerify(exactly = 1) { axsysClient.getEnheter(validToken, callId) }
-                verify(exactly = 1) {
-                    redisStore.setObject(
-                        key = cacheKey,
-                        value = Tilgang(harTilgang = false),
-                        expireSeconds = TWELVE_HOURS_IN_SECONDS
-                    )
-                }
+                verifyCacheSet(exactly = 1, key = cacheKey, harTilgang = false)
             }
 
             it("return result from cache hit") {
                 val enhet = Enhet(UserConstants.VEILEDER_ENHET)
                 val cacheKey = "tilgang-til-enhet-${UserConstants.VEILEDER_IDENT}-$enhet"
                 val callId = "123"
-                every { redisStore.getObject<Tilgang?>(cacheKey) } returns Tilgang(harTilgang = true)
+                every { redisStore.getObject<Tilgang?>(cacheKey) } returns Tilgang(erGodkjent = true)
 
                 runBlocking {
                     val tilgang = tilgangService.hasTilgangToEnhet(validToken, callId, enhet)
 
-                    tilgang.harTilgang shouldBeEqualTo true
+                    tilgang.erGodkjent shouldBeEqualTo true
                 }
 
                 verify(exactly = 1) { redisStore.getObject<Tilgang?>(key = cacheKey) }
+                coVerify(exactly = 0) { graphApiClient.hasAccess(any(), any(), any()) }
                 coVerify(exactly = 0) { axsysClient.getEnheter(any(), any()) }
-                verify(exactly = 0) { redisStore.setObject<Any>(any(), any(), any()) }
+                verifyCacheSet(exactly = 0)
             }
         }
     }


### PR DESCRIPTION
Geir oppdaget at vi gjorde dette i `syfo-tilgangskontroll`, så lurte på om vi skulle gjøre det samme her.

Jeg skjønte ikke heeelt den `@Cache`-greia i `syfo-tilgangskontroll`, men i dette tilfellet så cacher vi ikke `harTilgang = false` på enhet dersom det feiler på syfo-sjekken. Tenker det gir mening fordi vi egentlig ikke har sjekket mot Axsys om veilederen har tilgang til enheten hvis funksjonen returnerer allerede på syfo-sjekken. Hva synes dere?