### PR TITLE
Remove clientID from norg env

### DIFF
--- a/src/main/kotlin/no/nav/syfo/App.kt
+++ b/src/main/kotlin/no/nav/syfo/App.kt
@@ -64,9 +64,7 @@ fun main() {
     )
 
     val norgClient = NorgClient(
-        azureAdClient = azureAdClient,
-        baseUrl = environment.clients.norg.baseUrl,
-        clientId = environment.clients.norg.clientId,
+        baseUrl = environment.clients.norgUrl,
     )
 
     val wellKnownInternalAzureAD = getWellKnown(

--- a/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
@@ -45,10 +45,7 @@ data class Environment(
             baseUrl = getEnvVar("SYFOBEHANDLENDEENHET_URL"),
             clientId = getEnvVar("SYFOBEHANDLENDEENHET_CLIENT_ID")
         ),
-        norg = ClientEnvironment(
-            baseUrl = getEnvVar("NORG_URL"),
-            clientId = getEnvVar("NORG_CLIENT_ID")
-        ),
+        norgUrl = getEnvVar("NORG2_URL"),
     ),
 
 )

--- a/src/main/kotlin/no/nav/syfo/application/ClientsEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/application/ClientsEnvironment.kt
@@ -6,7 +6,7 @@ data class ClientsEnvironment(
     val skjermedePersoner: ClientEnvironment,
     val pdl: ClientEnvironment,
     val behandlendeEnhet: ClientEnvironment,
-    val norg: ClientEnvironment,
+    val norgUrl: String,
 )
 
 data class ClientEnvironment(

--- a/src/main/kotlin/no/nav/syfo/client/norg/NorgClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/norg/NorgClient.kt
@@ -5,7 +5,6 @@ import io.ktor.client.call.*
 import io.ktor.client.plugins.*
 import io.ktor.client.request.*
 import io.ktor.http.*
-import no.nav.syfo.client.azuread.AzureAdClient
 import no.nav.syfo.client.httpClientDefault
 import no.nav.syfo.client.norg.domain.NorgEnhet
 import no.nav.syfo.tilgang.Enhet
@@ -14,9 +13,7 @@ import no.nav.syfo.util.callIdArgument
 import org.slf4j.LoggerFactory.getLogger
 
 class NorgClient(
-    private val azureAdClient: AzureAdClient,
     private val baseUrl: String,
-    private val clientId: String,
     private val httpClient: HttpClient = httpClientDefault(),
 ) {
 

--- a/src/test/kotlin/no/nav/syfo/testhelper/TestApiModule.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/TestApiModule.kt
@@ -61,9 +61,7 @@ fun Application.testApiModule(
     )
 
     val norgClient = NorgClient(
-        azureAdClient = azureAdClient,
-        baseUrl = externalMockEnvironment.environment.clients.norg.baseUrl,
-        clientId = externalMockEnvironment.environment.clients.norg.clientId,
+        baseUrl = externalMockEnvironment.environment.clients.norgUrl,
         httpClient = mockHttpClient,
     )
 

--- a/src/test/kotlin/no/nav/syfo/testhelper/TestEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/TestEnvironment.kt
@@ -44,10 +44,7 @@ fun testEnvironment() = Environment(
             baseUrl = "behandlendeEnhetBaseurl",
             clientId = "behandlendeEnhetClientId",
         ),
-        norg = ClientEnvironment(
-            baseUrl = "norgBaseurl",
-            clientId = "norgClientId",
-        ),
+        norgUrl = "norgBaseurl",
     ),
 )
 


### PR DESCRIPTION
Also remove azureAdClient.
We don't use token for calls to norg2, so clientID and azureAdClient is not needed.
Fixes failing deploy to dev.