### PR TITLE
Add endpoint for preloading person info cache

### DIFF
--- a/src/main/kotlin/no/nav/syfo/tilgang/TilgangApi.kt
+++ b/src/main/kotlin/no/nav/syfo/tilgang/TilgangApi.kt
@@ -2,6 +2,7 @@ package no.nav.syfo.tilgang
 
 import io.ktor.http.*
 import io.ktor.server.application.*
+import io.ktor.server.request.*
 import io.ktor.server.response.*
 import io.ktor.server.routing.*
 import no.nav.syfo.application.api.auth.getNAVIdent
@@ -111,6 +112,22 @@ fun Route.registerTilgangApi(
                     message = tilgang
                 )
             }
+        }
+
+        post("/system/preloadbrukere") {
+            val callId = call.getCallId()
+            val token = call.getBearerHeader()
+                ?: throw IllegalArgumentException("Failed to preload cache: No Authorization header supplied, callId=$callId")
+
+            val personidenter = call.receive<List<String>>()
+
+            tilgangService.preloadCacheForPersonAccess(
+                token = token,
+                callId = callId,
+                personidenter = personidenter,
+            )
+
+            call.respond(HttpStatusCode.OK)
         }
     }
 }

--- a/src/test/kotlin/no/nav/syfo/tilgang/TilgangApiSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/tilgang/TilgangApiSpek.kt
@@ -218,6 +218,28 @@ class TilgangApiSpek : Spek({
                     }
                 }
             }
+
+            describe("preload cache") {
+                it("return OK after loading cache") {
+                    val validToken = generateJWT(
+                        audience = externalMockEnvironment.environment.azure.appClientId,
+                        issuer = externalMockEnvironment.wellKnownInternalAzureAD.issuer,
+                        navIdent = UserConstants.VEILEDER_IDENT,
+                    )
+                    val requestBody = listOf(UserConstants.PERSONIDENT)
+
+                    with(
+                        handleRequest(HttpMethod.Post, "$tilgangApiBasePath/system/preloadbrukere") {
+                            addHeader(HttpHeaders.Authorization, bearerHeader(validToken))
+                            addHeader(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                            addHeader(NAV_CALL_ID_HEADER, "123")
+                            setBody(objectMapper.writeValueAsString(requestBody))
+                        }
+                    ) {
+                        response.status() shouldBeEqualTo HttpStatusCode.OK
+                    }
+                }
+            }
         }
     }
 })


### PR DESCRIPTION
Receive list of string identer, it seems jackson can't deserialize into a value class. Preload cache for info about innbygger, this is initiated by system so we have no info about veiledere.