### PR TITLE
IS-1685: Use system token when preloading cache

### DIFF
--- a/src/main/kotlin/no/nav/syfo/tilgang/TilgangApi.kt
+++ b/src/main/kotlin/no/nav/syfo/tilgang/TilgangApi.kt
@@ -116,13 +116,9 @@ fun Route.registerTilgangApi(
 
         post("/system/preloadbrukere") {
             val callId = call.getCallId()
-            val token = call.getBearerHeader()
-                ?: throw IllegalArgumentException("Failed to preload cache: No Authorization header supplied, callId=$callId")
-
             val personidenter = call.receive<List<String>>()
 
             tilgangService.preloadCacheForPersonAccess(
-                token = token,
                 callId = callId,
                 personidenter = personidenter,
             )

--- a/src/main/kotlin/no/nav/syfo/tilgang/TilgangService.kt
+++ b/src/main/kotlin/no/nav/syfo/tilgang/TilgangService.kt
@@ -107,7 +107,7 @@ class TilgangService(
             return true
         }
 
-        val behandlendeEnhetDTO = behandlendeEnhetClient.getEnhet(
+        val behandlendeEnhetDTO = behandlendeEnhetClient.getEnhetWithOboToken(
             callId = callId,
             personident = personident,
             token = token,
@@ -144,7 +144,7 @@ class TilgangService(
         personident: Personident,
         token: Token,
     ): Boolean {
-        val person = pdlClient.person(
+        val person = pdlClient.getPersonWithOboToken(
             callId = callId,
             personident = personident,
             token = token,
@@ -160,7 +160,7 @@ class TilgangService(
     }
 
     private suspend fun isSkjermetAccessGodkjent(callId: String, personident: Personident, token: Token): Boolean {
-        val personIsSkjermet = skjermedePersonerPipClient.isSkjermet(
+        val personIsSkjermet = skjermedePersonerPipClient.getIsSkjermetWithOboToken(
             callId = callId,
             personIdent = personident,
             token = token,
@@ -207,34 +207,30 @@ class TilgangService(
         return tilgang
     }
 
-    private suspend fun preloadPersonInfoCache(token: Token, callId: String, personident: Personident) {
+    private suspend fun preloadPersonInfoCache(callId: String, personident: Personident) {
         try {
-            behandlendeEnhetClient.getEnhet(
+            behandlendeEnhetClient.getEnhetWithSystemToken(
                 callId = callId,
                 personident = personident,
-                token = token,
             )
 
-            skjermedePersonerPipClient.isSkjermet(
+            skjermedePersonerPipClient.getIsSkjermetWithSystemToken(
                 callId = callId,
                 personIdent = personident,
-                token = token,
             )
 
-            pdlClient.person(
+            pdlClient.getPersonWithSystemToken(
                 callId = callId,
                 personident = personident,
-                token = token,
             )
         } catch (e: Exception) {
             log.error("Failed to preload cache callId=$callId", e)
         }
     }
 
-    suspend fun preloadCacheForPersonAccess(token: Token, callId: String, personidenter: List<String>) {
+    suspend fun preloadCacheForPersonAccess(callId: String, personidenter: List<String>) {
         personidenter.map { Personident(it) }.forEach { personident ->
             preloadPersonInfoCache(
-                token = token,
                 callId = callId,
                 personident = personident,
             )

--- a/src/test/kotlin/no/nav/syfo/tilgang/TilgangServicePersonSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/tilgang/TilgangServicePersonSpek.kt
@@ -91,8 +91,8 @@ class TilgangServicePersonSpek : Spek({
 
                 beforeEachTest {
                     coEvery { graphApiClient.hasAccess(adRoller.NASJONAL, any(), any()) } returns true
-                    coEvery { skjermedePersonerPipClient.isSkjermet(any(), personident, any()) } returns false
-                    coEvery { pdlClient.person(any(), personident, any()) } returns ugradertInnbygger
+                    coEvery { skjermedePersonerPipClient.getIsSkjermetWithOboToken(any(), personident, any()) } returns false
+                    coEvery { pdlClient.getPersonWithOboToken(any(), personident, any()) } returns ugradertInnbygger
                 }
 
                 it("Return no access if veileder doesn't have SYFO access") {
@@ -150,8 +150,8 @@ class TilgangServicePersonSpek : Spek({
 
                 beforeEachTest {
                     coEvery { graphApiClient.hasAccess(adRoller.SYFO, any(), any()) } returns true
-                    coEvery { skjermedePersonerPipClient.isSkjermet(any(), personident, any()) } returns false
-                    coEvery { pdlClient.person(any(), personident, any()) } returns ugradertInnbygger
+                    coEvery { skjermedePersonerPipClient.getIsSkjermetWithOboToken(any(), personident, any()) } returns false
+                    coEvery { pdlClient.getPersonWithOboToken(any(), personident, any()) } returns ugradertInnbygger
                 }
 
                 it("Return access if veileder has nasjonal tilgang") {
@@ -180,7 +180,7 @@ class TilgangServicePersonSpek : Spek({
                         )
                     }
                     coVerify(exactly = 0) {
-                        behandlendeEnhetClient.getEnhet(any(), personident, any())
+                        behandlendeEnhetClient.getEnhetWithOboToken(any(), personident, any())
                     }
                     coVerify(exactly = 0) {
                         axsysClient.getEnheter(any(), any())
@@ -196,7 +196,7 @@ class TilgangServicePersonSpek : Spek({
                     )
                     every { redisStore.getObject<Tilgang?>(any()) } returns null
                     coEvery { graphApiClient.hasAccess(adRoller.NASJONAL, any(), any()) } returns false
-                    coEvery { behandlendeEnhetClient.getEnhet(any(), personident, any()) } returns innbyggerEnhet
+                    coEvery { behandlendeEnhetClient.getEnhetWithOboToken(any(), personident, any()) } returns innbyggerEnhet
                     coEvery { axsysClient.getEnheter(any(), any()) } returns listOf(veiledersEnhet)
 
                     runBlocking {
@@ -221,7 +221,7 @@ class TilgangServicePersonSpek : Spek({
                         )
                     }
                     coVerify(exactly = 1) {
-                        behandlendeEnhetClient.getEnhet(
+                        behandlendeEnhetClient.getEnhetWithOboToken(
                             callId = callId,
                             personident = personident,
                             token = validToken,
@@ -250,7 +250,7 @@ class TilgangServicePersonSpek : Spek({
                     )
                     every { redisStore.getObject<Tilgang?>(any()) } returns null
                     coEvery { graphApiClient.hasAccess(adRoller.NASJONAL, any(), any()) } returns false
-                    coEvery { behandlendeEnhetClient.getEnhet(any(), personident, any()) } returns innbyggerEnhet
+                    coEvery { behandlendeEnhetClient.getEnhetWithOboToken(any(), personident, any()) } returns innbyggerEnhet
                     coEvery { axsysClient.getEnheter(any(), any()) } returns listOf(veiledersEnhet)
 
                     runBlocking {
@@ -275,7 +275,7 @@ class TilgangServicePersonSpek : Spek({
                         )
                     }
                     coVerify(exactly = 1) {
-                        behandlendeEnhetClient.getEnhet(
+                        behandlendeEnhetClient.getEnhetWithOboToken(
                             callId = callId,
                             personident = personident,
                             token = validToken,
@@ -306,7 +306,7 @@ class TilgangServicePersonSpek : Spek({
                     every { redisStore.getObject<Tilgang?>(any()) } returns null
                     coEvery { graphApiClient.hasAccess(adRoller.NASJONAL, any(), any()) } returns false
                     coEvery { graphApiClient.hasAccess(adRoller.REGIONAL, any(), any()) } returns true
-                    coEvery { behandlendeEnhetClient.getEnhet(any(), personident, any()) } returns innbyggerEnhet
+                    coEvery { behandlendeEnhetClient.getEnhetWithOboToken(any(), personident, any()) } returns innbyggerEnhet
                     coEvery { axsysClient.getEnheter(any(), any()) } returns listOf(veiledersEnhet)
                     coEvery { norgClient.getOverordnetEnhetListForNAVKontor(any(), any()) } returns listOf(
                         overordnetEnhet
@@ -327,7 +327,7 @@ class TilgangServicePersonSpek : Spek({
                         )
                     }
                     coVerify(exactly = 1) {
-                        behandlendeEnhetClient.getEnhet(
+                        behandlendeEnhetClient.getEnhetWithOboToken(
                             callId = callId,
                             personident = personident,
                             token = validToken,
@@ -368,12 +368,12 @@ class TilgangServicePersonSpek : Spek({
                 beforeEachTest {
                     coEvery { graphApiClient.hasAccess(adRoller.SYFO, any(), any()) } returns true
                     coEvery { graphApiClient.hasAccess(adRoller.NASJONAL, any(), any()) } returns true
-                    coEvery { pdlClient.person(any(), personident, any()) } returns ugradertInnbygger
+                    coEvery { pdlClient.getPersonWithOboToken(any(), personident, any()) } returns ugradertInnbygger
                 }
 
                 it("Return no access if person is skjermet and veileder doesn't have correct AdRolle") {
                     every { redisStore.getObject<Tilgang?>(any()) } returns null
-                    coEvery { skjermedePersonerPipClient.isSkjermet(any(), personident, any()) } returns true
+                    coEvery { skjermedePersonerPipClient.getIsSkjermetWithOboToken(any(), personident, any()) } returns true
                     coEvery { graphApiClient.hasAccess(adRoller.EGEN_ANSATT, any(), any()) } returns false
 
                     runBlocking {
@@ -384,7 +384,7 @@ class TilgangServicePersonSpek : Spek({
 
                     verify(exactly = 1) { redisStore.getObject<Tilgang?>(key = cacheKey) }
                     coVerify(exactly = 1) {
-                        skjermedePersonerPipClient.isSkjermet(
+                        skjermedePersonerPipClient.getIsSkjermetWithOboToken(
                             callId = callId,
                             personIdent = personident,
                             token = validToken
@@ -402,7 +402,7 @@ class TilgangServicePersonSpek : Spek({
 
                 it("return godkjent access if person is skjermet and veileder has correct AdRolle") {
                     every { redisStore.getObject<Tilgang?>(any()) } returns null
-                    coEvery { skjermedePersonerPipClient.isSkjermet(any(), personident, any()) } returns true
+                    coEvery { skjermedePersonerPipClient.getIsSkjermetWithOboToken(any(), personident, any()) } returns true
                     coEvery { graphApiClient.hasAccess(adRoller.EGEN_ANSATT, any(), any()) } returns true
 
                     runBlocking {
@@ -413,7 +413,7 @@ class TilgangServicePersonSpek : Spek({
 
                     verify(exactly = 1) { redisStore.getObject<Tilgang?>(key = cacheKey) }
                     coVerify(exactly = 1) {
-                        skjermedePersonerPipClient.isSkjermet(
+                        skjermedePersonerPipClient.getIsSkjermetWithOboToken(
                             callId = callId,
                             personIdent = personident,
                             token = validToken
@@ -438,7 +438,7 @@ class TilgangServicePersonSpek : Spek({
                 beforeEachTest {
                     coEvery { graphApiClient.hasAccess(adRoller.SYFO, any(), any()) } returns true
                     coEvery { graphApiClient.hasAccess(adRoller.NASJONAL, any(), any()) } returns true
-                    coEvery { skjermedePersonerPipClient.isSkjermet(any(), personident, any()) } returns false
+                    coEvery { skjermedePersonerPipClient.getIsSkjermetWithOboToken(any(), personident, any()) } returns false
                 }
 
                 it("Return no access if person is kode6 and veileder doesn't have correct AdRolle") {
@@ -448,7 +448,7 @@ class TilgangServicePersonSpek : Spek({
                         ),
                     )
                     every { redisStore.getObject<Tilgang?>(any()) } returns null
-                    coEvery { pdlClient.person(any(), personident, any()) } returns personWithKode6
+                    coEvery { pdlClient.getPersonWithOboToken(any(), personident, any()) } returns personWithKode6
                     coEvery { graphApiClient.hasAccess(adRoller.KODE6, any(), any()) } returns false
 
                     runBlocking {
@@ -459,7 +459,7 @@ class TilgangServicePersonSpek : Spek({
 
                     verify(exactly = 1) { redisStore.getObject<Tilgang?>(key = cacheKey) }
                     coVerify(exactly = 1) {
-                        pdlClient.person(
+                        pdlClient.getPersonWithOboToken(
                             callId = callId,
                             personident = personident,
                             token = validToken,
@@ -489,7 +489,7 @@ class TilgangServicePersonSpek : Spek({
                         ),
                     )
                     every { redisStore.getObject<Tilgang?>(any()) } returns null
-                    coEvery { pdlClient.person(any(), personident, any()) } returns personWithKode7
+                    coEvery { pdlClient.getPersonWithOboToken(any(), personident, any()) } returns personWithKode7
                     coEvery { graphApiClient.hasAccess(adRoller.KODE7, any(), any()) } returns false
 
                     runBlocking {
@@ -500,7 +500,7 @@ class TilgangServicePersonSpek : Spek({
 
                     verify(exactly = 1) { redisStore.getObject<Tilgang?>(key = cacheKey) }
                     coVerify(exactly = 1) {
-                        pdlClient.person(
+                        pdlClient.getPersonWithOboToken(
                             callId = callId,
                             personident = personident,
                             token = validToken,
@@ -530,7 +530,7 @@ class TilgangServicePersonSpek : Spek({
                         ),
                     )
                     every { redisStore.getObject<Tilgang?>(any()) } returns null
-                    coEvery { pdlClient.person(any(), personident, any()) } returns personWithKode6
+                    coEvery { pdlClient.getPersonWithOboToken(any(), personident, any()) } returns personWithKode6
                     coEvery { graphApiClient.hasAccess(adRoller.KODE6, any(), any()) } returns true
 
                     runBlocking {
@@ -541,7 +541,7 @@ class TilgangServicePersonSpek : Spek({
 
                     verify(exactly = 1) { redisStore.getObject<Tilgang?>(key = cacheKey) }
                     coVerify(exactly = 1) {
-                        pdlClient.person(
+                        pdlClient.getPersonWithOboToken(
                             callId = callId,
                             personident = personident,
                             token = validToken,
@@ -571,7 +571,7 @@ class TilgangServicePersonSpek : Spek({
                         ),
                     )
                     every { redisStore.getObject<Tilgang?>(any()) } returns null
-                    coEvery { pdlClient.person(any(), personident, any()) } returns personWithKode7
+                    coEvery { pdlClient.getPersonWithOboToken(any(), personident, any()) } returns personWithKode7
                     coEvery { graphApiClient.hasAccess(adRoller.KODE7, any(), any()) } returns true
 
                     runBlocking {
@@ -582,7 +582,7 @@ class TilgangServicePersonSpek : Spek({
 
                     verify(exactly = 1) { redisStore.getObject<Tilgang?>(key = cacheKey) }
                     coVerify(exactly = 1) {
-                        pdlClient.person(
+                        pdlClient.getPersonWithOboToken(
                             callId = callId,
                             personident = personident,
                             token = validToken,
@@ -612,7 +612,7 @@ class TilgangServicePersonSpek : Spek({
                         ),
                     )
                     every { redisStore.getObject<Tilgang?>(any()) } returns null
-                    coEvery { pdlClient.person(any(), personident, any()) } returns ugradertInnbygger
+                    coEvery { pdlClient.getPersonWithOboToken(any(), personident, any()) } returns ugradertInnbygger
 
                     runBlocking {
                         val tilgang = tilgangService.hasTilgangToPerson(validToken, personident, callId)
@@ -622,7 +622,7 @@ class TilgangServicePersonSpek : Spek({
 
                     verify(exactly = 1) { redisStore.getObject<Tilgang?>(key = cacheKey) }
                     coVerify(exactly = 1) {
-                        pdlClient.person(
+                        pdlClient.getPersonWithOboToken(
                             callId = callId,
                             personident = personident,
                             token = validToken,
@@ -659,7 +659,7 @@ class TilgangServicePersonSpek : Spek({
                 }
 
                 verify(exactly = 1) { redisStore.getObject<Tilgang?>(key = cacheKey) }
-                coVerify(exactly = 0) { skjermedePersonerPipClient.isSkjermet(any(), personident, any()) }
+                coVerify(exactly = 0) { skjermedePersonerPipClient.getIsSkjermetWithOboToken(any(), personident, any()) }
                 coVerify(exactly = 0) { graphApiClient.hasAccess(any(), any(), any()) }
                 verifyCacheSet(exactly = 0)
             }

--- a/src/test/kotlin/no/nav/syfo/tilgang/TilgangServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/tilgang/TilgangServiceSpek.kt
@@ -179,21 +179,20 @@ class TilgangServiceSpek : Spek({
                 val callId = "123"
                 val personident = Personident(UserConstants.PERSONIDENT)
                 val personidenter = listOf(UserConstants.PERSONIDENT)
-                coJustRun { behandlendeEnhetClient.getEnhet(any(), personident, any()) }
-                coJustRun { skjermedePersonerPipClient.isSkjermet(any(), personident, any()) }
-                coJustRun { pdlClient.person(any(), personident, any()) }
+                coJustRun { behandlendeEnhetClient.getEnhetWithSystemToken(any(), personident) }
+                coJustRun { skjermedePersonerPipClient.getIsSkjermetWithSystemToken(any(), personident) }
+                coJustRun { pdlClient.getPersonWithSystemToken(any(), personident) }
 
                 runBlocking {
                     tilgangService.preloadCacheForPersonAccess(
-                        token = validToken,
                         callId = callId,
                         personidenter = personidenter,
                     )
                 }
 
-                coVerify(exactly = 1) { behandlendeEnhetClient.getEnhet(callId, personident, validToken) }
-                coVerify(exactly = 1) { skjermedePersonerPipClient.isSkjermet(callId, personident, validToken) }
-                coVerify(exactly = 1) { pdlClient.person(callId, personident, validToken) }
+                coVerify(exactly = 1) { behandlendeEnhetClient.getEnhetWithSystemToken(callId, personident) }
+                coVerify(exactly = 1) { skjermedePersonerPipClient.getIsSkjermetWithSystemToken(callId, personident) }
+                coVerify(exactly = 1) { pdlClient.getPersonWithSystemToken(callId, personident) }
             }
 
             it("gets data from behandledeEnhet, skjermedePersonerPip and pdl for each person in list") {
@@ -201,27 +200,26 @@ class TilgangServiceSpek : Spek({
                 val personident1 = Personident(UserConstants.PERSONIDENT)
                 val personident2 = Personident(UserConstants.PERSONIDENT_GRADERT)
                 val personidenter = listOf(UserConstants.PERSONIDENT, UserConstants.PERSONIDENT_GRADERT)
-                coJustRun { behandlendeEnhetClient.getEnhet(any(), personident1, any()) }
-                coJustRun { behandlendeEnhetClient.getEnhet(any(), personident2, any()) }
-                coJustRun { skjermedePersonerPipClient.isSkjermet(any(), personident1, any()) }
-                coJustRun { skjermedePersonerPipClient.isSkjermet(any(), personident2, any()) }
-                coJustRun { pdlClient.person(any(), personident1, any()) }
-                coJustRun { pdlClient.person(any(), personident2, any()) }
+                coJustRun { behandlendeEnhetClient.getEnhetWithSystemToken(any(), personident1) }
+                coJustRun { behandlendeEnhetClient.getEnhetWithSystemToken(any(), personident2) }
+                coJustRun { skjermedePersonerPipClient.getIsSkjermetWithSystemToken(any(), personident1) }
+                coJustRun { skjermedePersonerPipClient.getIsSkjermetWithSystemToken(any(), personident2) }
+                coJustRun { pdlClient.getPersonWithSystemToken(any(), personident1) }
+                coJustRun { pdlClient.getPersonWithSystemToken(any(), personident2) }
 
                 runBlocking {
                     tilgangService.preloadCacheForPersonAccess(
-                        token = validToken,
                         callId = callId,
                         personidenter = personidenter,
                     )
                 }
 
-                coVerify(exactly = 1) { behandlendeEnhetClient.getEnhet(callId, personident1, validToken) }
-                coVerify(exactly = 1) { behandlendeEnhetClient.getEnhet(callId, personident2, validToken) }
-                coVerify(exactly = 1) { skjermedePersonerPipClient.isSkjermet(callId, personident1, validToken) }
-                coVerify(exactly = 1) { skjermedePersonerPipClient.isSkjermet(callId, personident2, validToken) }
-                coVerify(exactly = 1) { pdlClient.person(callId, personident1, validToken) }
-                coVerify(exactly = 1) { pdlClient.person(callId, personident2, validToken) }
+                coVerify(exactly = 1) { behandlendeEnhetClient.getEnhetWithSystemToken(callId, personident1) }
+                coVerify(exactly = 1) { behandlendeEnhetClient.getEnhetWithSystemToken(callId, personident2) }
+                coVerify(exactly = 1) { skjermedePersonerPipClient.getIsSkjermetWithSystemToken(callId, personident1) }
+                coVerify(exactly = 1) { skjermedePersonerPipClient.getIsSkjermetWithSystemToken(callId, personident2) }
+                coVerify(exactly = 1) { pdlClient.getPersonWithSystemToken(callId, personident1) }
+                coVerify(exactly = 1) { pdlClient.getPersonWithSystemToken(callId, personident2) }
             }
         }
     }


### PR DESCRIPTION
syfooversiktsrv preloades cache from a cronjob so the cache is ready before veiledere start working, therefore it uses a system token.
syfobehandlendeenhet has a specific endpoint for system token, but it gets the same info as the obo token endpoint, so the data filled in cache should be correct regardless.
Set token to nullable in clients and check if token is null in AzureAdClient to decide whether to use system token or obo token, that way existing calls to clients remain the same as before.