### PR TITLE
IS-1697: Validate consumerClientIdAzp in preload api

### DIFF
--- a/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/application/ApplicationEnvironment.kt
@@ -1,14 +1,17 @@
 package no.nav.syfo.application
 
+import com.fasterxml.jackson.module.kotlin.readValue
 import io.ktor.server.application.*
 import no.nav.syfo.cache.RedisEnvironment
 import no.nav.syfo.client.azuread.AzureEnvironment
+import no.nav.syfo.util.configuredJacksonMapper
 
 data class Environment(
 
     val azure: AzureEnvironment = AzureEnvironment(
         appClientId = getEnvVar("AZURE_APP_CLIENT_ID"),
         appClientSecret = getEnvVar("AZURE_APP_CLIENT_SECRET"),
+        preAuthorizedApps = configuredJacksonMapper().readValue(getEnvVar("AZURE_APP_PRE_AUTHORIZED_APPS")),
         appWellKnownUrl = getEnvVar("AZURE_APP_WELL_KNOWN_URL"),
         openidConfigTokenEndpoint = getEnvVar("AZURE_OPENID_CONFIG_TOKEN_ENDPOINT"),
     ),

--- a/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
+++ b/src/main/kotlin/no/nav/syfo/application/api/ApiModule.kt
@@ -63,6 +63,7 @@ fun Application.apiModule(
         authenticate(JwtIssuerType.INTERNAL_AZUREAD.name) {
             registerTilgangApi(
                 tilgangService = tilgangService,
+                preAuthorizedApps = environment.azure.preAuthorizedApps,
             )
         }
     }

--- a/src/main/kotlin/no/nav/syfo/application/api/ApiPlugins.kt
+++ b/src/main/kotlin/no/nav/syfo/application/api/ApiPlugins.kt
@@ -10,6 +10,7 @@ import io.ktor.server.plugins.contentnegotiation.*
 import io.ktor.server.plugins.statuspages.*
 import io.ktor.server.response.*
 import io.micrometer.core.instrument.distribution.DistributionStatisticConfig
+import no.nav.syfo.application.exception.ForbiddenAccessSystemConsumer
 import no.nav.syfo.application.exception.ForbiddenAccessVeilederException
 import no.nav.syfo.application.metric.METRICS_REGISTRY
 import no.nav.syfo.util.*
@@ -67,6 +68,9 @@ fun Application.installStatusPages() {
                     HttpStatusCode.BadRequest
                 }
                 is ForbiddenAccessVeilederException -> {
+                    HttpStatusCode.Forbidden
+                }
+                is ForbiddenAccessSystemConsumer -> {
                     HttpStatusCode.Forbidden
                 }
                 else -> {

--- a/src/main/kotlin/no/nav/syfo/application/exception/ForbiddenAccessSystemConsumer.kt
+++ b/src/main/kotlin/no/nav/syfo/application/exception/ForbiddenAccessSystemConsumer.kt
@@ -1,0 +1,6 @@
+package no.nav.syfo.application.exception
+
+class ForbiddenAccessSystemConsumer(
+    consumerClientIdAzp: String,
+    message: String = "Consumer with clientId(azp)=$consumerClientIdAzp is denied access to system API",
+) : RuntimeException(message)

--- a/src/main/kotlin/no/nav/syfo/client/azuread/AzureEnvironment.kt
+++ b/src/main/kotlin/no/nav/syfo/client/azuread/AzureEnvironment.kt
@@ -3,6 +3,17 @@ package no.nav.syfo.client.azuread
 data class AzureEnvironment(
     val appClientId: String,
     val appClientSecret: String,
+    val preAuthorizedApps: List<PreAuthorizedApp>,
     val appWellKnownUrl: String,
     val openidConfigTokenEndpoint: String
 )
+
+data class PreAuthorizedApp(
+    val name: String,
+    val clientId: String
+) {
+    fun getAppnavn(): String {
+        val split = name.split(":")
+        return split[2]
+    }
+}

--- a/src/test/kotlin/no/nav/syfo/testhelper/JWTUtil.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/JWTUtil.kt
@@ -5,6 +5,7 @@ import com.auth0.jwt.algorithms.Algorithm
 import com.nimbusds.jose.jwk.JWKSet
 import com.nimbusds.jose.jwk.RSAKey
 import no.nav.syfo.application.api.auth.JWT_CLAIM_NAVIDENT
+import no.nav.syfo.util.JWT_CLAIM_AZP
 import java.io.IOException
 import java.nio.charset.StandardCharsets
 import java.nio.file.Files
@@ -20,6 +21,7 @@ const val keyId = "localhost-signer"
 fun generateJWT(
     audience: String,
     issuer: String,
+    azp: String? = null,
     navIdent: String? = null,
     subject: String? = null,
     expiry: LocalDateTime? = LocalDateTime.now().plusHours(1)
@@ -41,6 +43,7 @@ fun generateJWT(
         .withClaim("iat", now)
         .withClaim("exp", Date.from(expiry?.atZone(ZoneId.systemDefault())?.toInstant()))
         .withClaim(JWT_CLAIM_NAVIDENT, navIdent)
+        .withClaim(JWT_CLAIM_AZP, azp)
         .sign(alg)
 }
 

--- a/src/test/kotlin/no/nav/syfo/testhelper/TestEnvironment.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/TestEnvironment.kt
@@ -3,11 +3,13 @@ package no.nav.syfo.testhelper
 import no.nav.syfo.application.*
 import no.nav.syfo.cache.RedisEnvironment
 import no.nav.syfo.client.azuread.AzureEnvironment
+import no.nav.syfo.client.azuread.PreAuthorizedApp
 
 fun testEnvironment() = Environment(
     azure = AzureEnvironment(
         appClientId = "istilgangskontroll-client-id",
         appClientSecret = "istilgangskontroll-secret",
+        preAuthorizedApps = testAzureAppPreAuthorizedApps,
         appWellKnownUrl = "wellknown",
         openidConfigTokenEndpoint = "azureOpenIdTokenEndpoint",
     ),
@@ -51,4 +53,14 @@ fun testEnvironment() = Environment(
 fun testAppState() = ApplicationState(
     alive = true,
     ready = true,
+)
+
+private const val syfooversiktsrvApplicationName: String = "syfooversiktsrv"
+const val syfooversiktsrvClientId = "$syfooversiktsrvApplicationName-client-id"
+
+val testAzureAppPreAuthorizedApps = listOf(
+    PreAuthorizedApp(
+        name = "cluster:teamsykefravr:$syfooversiktsrvApplicationName",
+        clientId = syfooversiktsrvClientId,
+    ),
 )


### PR DESCRIPTION
Validerer at det bare er `syfooversiktsrv` som får lov til å kalle preload-endepunktet