### PR TITLE
Fix metric endpoint

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -30,7 +30,7 @@ spec:
     cpuThresholdPercentage: 90
   prometheus:
     enabled: true
-    path: /internal/metrics/prometheus
+    path: /internal/metrics
   ingresses:
     - "https://istilgangskontroll.intern.dev.nav.no"
   accessPolicy:

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -30,7 +30,7 @@ spec:
     cpuThresholdPercentage: 90
   prometheus:
     enabled: true
-    path: /internal/metrics/prometheus
+    path: /internal/metrics
   ingresses:
     - "https://istilgangskontroll.intern.nav.no"
   accessPolicy:

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,7 +19,7 @@ object Versions {
 }
 
 plugins {
-    kotlin("jvm") version "1.9.0"
+    kotlin("jvm") version "1.9.20"
     id("com.github.johnrengelman.shadow") version "8.1.1"
     id("org.jlleitschuh.gradle.ktlint") version "11.4.1"
 }

--- a/src/main/kotlin/no/nav/syfo/client/graphapi/GraphApiClientMetric.kt
+++ b/src/main/kotlin/no/nav/syfo/client/graphapi/GraphApiClientMetric.kt
@@ -4,7 +4,7 @@ import io.micrometer.core.instrument.Counter
 import no.nav.syfo.application.metric.METRICS_NS
 import no.nav.syfo.application.metric.METRICS_REGISTRY
 
-const val CALL_GRAPHAPI_USER_GROUPS_PERSON_BASE = "${METRICS_NS}call_graphapi_user_groups"
+const val CALL_GRAPHAPI_USER_GROUPS_PERSON_BASE = "${METRICS_NS}_call_graphapi_user_groups"
 const val CALL_GRAPHAPI_USER_GROUPS_PERSON_SUCCESS = "${CALL_GRAPHAPI_USER_GROUPS_PERSON_BASE}_success_count"
 const val CALL_GRAPHAPI_USER_GROUPS_PERSON_FAIL = "${CALL_GRAPHAPI_USER_GROUPS_PERSON_BASE}_fail_count"
 


### PR DESCRIPTION
Metrics fra istilgangskontroll dukker ikke opp i Prometheus siden path'en i naiseratorfilene ikke er riktig.