### PR TITLE
IS-1732: Rename to checkTilgang()

### DIFF
--- a/src/main/kotlin/no/nav/syfo/tilgang/TilgangApi.kt
+++ b/src/main/kotlin/no/nav/syfo/tilgang/TilgangApi.kt
@@ -30,7 +30,7 @@ fun Route.registerTilgangApi(
                 throw IllegalArgumentException("Failed to check enhetstilgang for veileder. No NAV ident in token")
             }
 
-            val tilgang = tilgangService.hasTilgangToSyfo(
+            val tilgang = tilgangService.checkTilgangToSyfo(
                 token = token,
                 callId = callId,
             )
@@ -56,7 +56,7 @@ fun Route.registerTilgangApi(
             val enhetNr = call.parameters[enhetNr] ?: throw IllegalArgumentException("No EnhetNr found in path param")
             val enhet = Enhet(enhetNr)
 
-            val syfoTilgang = tilgangService.hasTilgangToSyfo(
+            val syfoTilgang = tilgangService.checkTilgangToSyfo(
                 token = token,
                 callId = callId,
             )
@@ -64,7 +64,7 @@ fun Route.registerTilgangApi(
             val tilgang = if (syfoTilgang.erAvslatt) {
                 syfoTilgang
             } else {
-                tilgangService.hasTilgangToEnhet(
+                tilgangService.checkTilgangToEnhet(
                     token = token,
                     callId = callId,
                     enhet = enhet,
@@ -93,7 +93,7 @@ fun Route.registerTilgangApi(
             val veilederIdent = token.getNAVIdent()
             val consumerClientId = call.getConsumerClientId() ?: ""
 
-            val tilgang = tilgangService.hasTilgangToPerson(
+            val tilgang = tilgangService.checkTilgangToPerson(
                 token = token,
                 personident = requestedPersonIdent,
                 callId = callId,

--- a/src/main/kotlin/no/nav/syfo/tilgang/TilgangService.kt
+++ b/src/main/kotlin/no/nav/syfo/tilgang/TilgangService.kt
@@ -31,7 +31,7 @@ class TilgangService(
         )
     }
 
-    suspend fun hasTilgangToSyfo(token: Token, callId: String): Tilgang {
+    suspend fun checkTilgangToSyfo(token: Token, callId: String): Tilgang {
         val veilederIdent = token.getNAVIdent()
         val cacheKey = "$TILGANG_TIL_TJENESTEN_PREFIX$veilederIdent"
         val cachedTilgang: Tilgang? = redisStore.getObject(key = cacheKey)
@@ -54,7 +54,7 @@ class TilgangService(
         return tilgang
     }
 
-    suspend fun hasTilgangToEnhet(token: Token, callId: String, enhet: Enhet): Tilgang {
+    suspend fun checkTilgangToEnhet(token: Token, callId: String, enhet: Enhet): Tilgang {
         val veilederIdent = token.getNAVIdent()
         val cacheKey = "$TILGANG_TIL_ENHET_PREFIX$veilederIdent-$enhet"
         val cachedTilgang: Tilgang? = redisStore.getObject(key = cacheKey)
@@ -177,7 +177,7 @@ class TilgangService(
         }
     }
 
-    suspend fun hasTilgangToPerson(token: Token, personident: Personident, callId: String): Tilgang {
+    suspend fun checkTilgangToPerson(token: Token, personident: Personident, callId: String): Tilgang {
         val veilederIdent = token.getNAVIdent()
         val cacheKey = "$TILGANG_TIL_PERSON_PREFIX$veilederIdent-$personident"
         val cachedTilgang: Tilgang? = redisStore.getObject(key = cacheKey)
@@ -209,7 +209,7 @@ class TilgangService(
 
     suspend fun filterIdenterByVeilederAccess(callId: String, token: Token, personidenter: List<String>): List<String> {
         return personidenter.filter { personident ->
-            hasTilgangToPerson(
+            checkTilgangToPerson(
                 token = token,
                 personident = Personident(personident),
                 callId = callId,

--- a/src/test/kotlin/no/nav/syfo/tilgang/TilgangServicePersonSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/tilgang/TilgangServicePersonSpek.kt
@@ -100,7 +100,7 @@ class TilgangServicePersonSpek : Spek({
                     coEvery { graphApiClient.hasAccess(adRoller.SYFO, any(), any()) } returns false
 
                     runBlocking {
-                        val tilgang = tilgangService.hasTilgangToPerson(validToken, personident, callId)
+                        val tilgang = tilgangService.checkTilgangToPerson(validToken, personident, callId)
 
                         tilgang.erGodkjent shouldBeEqualTo false
                     }
@@ -121,7 +121,7 @@ class TilgangServicePersonSpek : Spek({
                     coEvery { graphApiClient.hasAccess(adRoller.SYFO, any(), any()) } returns true
 
                     runBlocking {
-                        val tilgang = tilgangService.hasTilgangToPerson(validToken, personident, callId)
+                        val tilgang = tilgangService.checkTilgangToPerson(validToken, personident, callId)
 
                         tilgang.erGodkjent shouldBeEqualTo true
                     }
@@ -159,7 +159,7 @@ class TilgangServicePersonSpek : Spek({
                     coEvery { graphApiClient.hasAccess(adRoller.NASJONAL, any(), any()) } returns true
 
                     runBlocking {
-                        val tilgang = tilgangService.hasTilgangToPerson(validToken, personident, callId)
+                        val tilgang = tilgangService.checkTilgangToPerson(validToken, personident, callId)
 
                         tilgang.erGodkjent shouldBeEqualTo true
                     }
@@ -200,7 +200,7 @@ class TilgangServicePersonSpek : Spek({
                     coEvery { axsysClient.getEnheter(any(), any()) } returns listOf(veiledersEnhet)
 
                     runBlocking {
-                        val tilgang = tilgangService.hasTilgangToPerson(validToken, personident, callId)
+                        val tilgang = tilgangService.checkTilgangToPerson(validToken, personident, callId)
 
                         tilgang.erGodkjent shouldBeEqualTo false
                     }
@@ -254,7 +254,7 @@ class TilgangServicePersonSpek : Spek({
                     coEvery { axsysClient.getEnheter(any(), any()) } returns listOf(veiledersEnhet)
 
                     runBlocking {
-                        val tilgang = tilgangService.hasTilgangToPerson(validToken, personident, callId)
+                        val tilgang = tilgangService.checkTilgangToPerson(validToken, personident, callId)
 
                         tilgang.erGodkjent shouldBeEqualTo true
                     }
@@ -313,7 +313,7 @@ class TilgangServicePersonSpek : Spek({
                     )
 
                     runBlocking {
-                        val tilgang = tilgangService.hasTilgangToPerson(validToken, personident, callId)
+                        val tilgang = tilgangService.checkTilgangToPerson(validToken, personident, callId)
 
                         tilgang.erGodkjent shouldBeEqualTo true
                     }
@@ -377,7 +377,7 @@ class TilgangServicePersonSpek : Spek({
                     coEvery { graphApiClient.hasAccess(adRoller.EGEN_ANSATT, any(), any()) } returns false
 
                     runBlocking {
-                        val tilgang = tilgangService.hasTilgangToPerson(validToken, personident, callId)
+                        val tilgang = tilgangService.checkTilgangToPerson(validToken, personident, callId)
 
                         tilgang.erGodkjent shouldBeEqualTo false
                     }
@@ -406,7 +406,7 @@ class TilgangServicePersonSpek : Spek({
                     coEvery { graphApiClient.hasAccess(adRoller.EGEN_ANSATT, any(), any()) } returns true
 
                     runBlocking {
-                        val tilgang = tilgangService.hasTilgangToPerson(validToken, personident, callId)
+                        val tilgang = tilgangService.checkTilgangToPerson(validToken, personident, callId)
 
                         tilgang.erGodkjent shouldBeEqualTo true
                     }
@@ -452,7 +452,7 @@ class TilgangServicePersonSpek : Spek({
                     coEvery { graphApiClient.hasAccess(adRoller.KODE6, any(), any()) } returns false
 
                     runBlocking {
-                        val tilgang = tilgangService.hasTilgangToPerson(validToken, personident, callId)
+                        val tilgang = tilgangService.checkTilgangToPerson(validToken, personident, callId)
 
                         tilgang.erGodkjent shouldBeEqualTo false
                     }
@@ -493,7 +493,7 @@ class TilgangServicePersonSpek : Spek({
                     coEvery { graphApiClient.hasAccess(adRoller.KODE7, any(), any()) } returns false
 
                     runBlocking {
-                        val tilgang = tilgangService.hasTilgangToPerson(validToken, personident, callId)
+                        val tilgang = tilgangService.checkTilgangToPerson(validToken, personident, callId)
 
                         tilgang.erGodkjent shouldBeEqualTo false
                     }
@@ -534,7 +534,7 @@ class TilgangServicePersonSpek : Spek({
                     coEvery { graphApiClient.hasAccess(adRoller.KODE6, any(), any()) } returns true
 
                     runBlocking {
-                        val tilgang = tilgangService.hasTilgangToPerson(validToken, personident, callId)
+                        val tilgang = tilgangService.checkTilgangToPerson(validToken, personident, callId)
 
                         tilgang.erGodkjent shouldBeEqualTo true
                     }
@@ -575,7 +575,7 @@ class TilgangServicePersonSpek : Spek({
                     coEvery { graphApiClient.hasAccess(adRoller.KODE7, any(), any()) } returns true
 
                     runBlocking {
-                        val tilgang = tilgangService.hasTilgangToPerson(validToken, personident, callId)
+                        val tilgang = tilgangService.checkTilgangToPerson(validToken, personident, callId)
 
                         tilgang.erGodkjent shouldBeEqualTo true
                     }
@@ -615,7 +615,7 @@ class TilgangServicePersonSpek : Spek({
                     coEvery { pdlClient.getPersonWithOboToken(any(), personident, any()) } returns ugradertInnbygger
 
                     runBlocking {
-                        val tilgang = tilgangService.hasTilgangToPerson(validToken, personident, callId)
+                        val tilgang = tilgangService.checkTilgangToPerson(validToken, personident, callId)
 
                         tilgang.erGodkjent shouldBeEqualTo true
                     }
@@ -653,7 +653,7 @@ class TilgangServicePersonSpek : Spek({
                 every { redisStore.getObject<Tilgang?>(any()) } returns Tilgang(erGodkjent = true)
 
                 runBlocking {
-                    val tilgang = tilgangService.hasTilgangToPerson(validToken, personident, callId)
+                    val tilgang = tilgangService.checkTilgangToPerson(validToken, personident, callId)
 
                     tilgang.erGodkjent shouldBeEqualTo true
                 }

--- a/src/test/kotlin/no/nav/syfo/tilgang/TilgangServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/tilgang/TilgangServiceSpek.kt
@@ -84,7 +84,7 @@ class TilgangServiceSpek : Spek({
                 every { redisStore.getObject<Tilgang?>(any()) } returns Tilgang(erGodkjent = true)
 
                 runBlocking {
-                    tilgangService.hasTilgangToSyfo(validToken, callId)
+                    tilgangService.checkTilgangToSyfo(validToken, callId)
                 }
 
                 verify(exactly = 1) { redisStore.getObject<Tilgang?>(key = cacheKey) }
@@ -98,7 +98,7 @@ class TilgangServiceSpek : Spek({
                 coEvery { graphApiClient.hasAccess(any(), any(), any()) } returns true
 
                 runBlocking {
-                    tilgangService.hasTilgangToSyfo(validToken, callId)
+                    tilgangService.checkTilgangToSyfo(validToken, callId)
                 }
 
                 verify(exactly = 1) { redisStore.getObject<Tilgang?>(key = cacheKey) }
@@ -123,7 +123,7 @@ class TilgangServiceSpek : Spek({
                 coEvery { graphApiClient.hasAccess(any(), any(), any()) } returns true
 
                 runBlocking {
-                    val tilgang = tilgangService.hasTilgangToEnhet(validToken, callId, enhet)
+                    val tilgang = tilgangService.checkTilgangToEnhet(validToken, callId, enhet)
 
                     tilgang.erGodkjent shouldBeEqualTo true
                 }
@@ -146,7 +146,7 @@ class TilgangServiceSpek : Spek({
                 coEvery { axsysClient.getEnheter(validToken, callId) } returns listOf(veiledersEnhet)
 
                 runBlocking {
-                    val tilgang = tilgangService.hasTilgangToEnhet(validToken, callId, wantedEnhet)
+                    val tilgang = tilgangService.checkTilgangToEnhet(validToken, callId, wantedEnhet)
 
                     tilgang.erGodkjent shouldBeEqualTo false
                 }
@@ -163,7 +163,7 @@ class TilgangServiceSpek : Spek({
                 every { redisStore.getObject<Tilgang?>(cacheKey) } returns Tilgang(erGodkjent = true)
 
                 runBlocking {
-                    val tilgang = tilgangService.hasTilgangToEnhet(validToken, callId, enhet)
+                    val tilgang = tilgangService.checkTilgangToEnhet(validToken, callId, enhet)
 
                     tilgang.erGodkjent shouldBeEqualTo true
                 }


### PR DESCRIPTION
Funksjoner som returnerer `Tilgang`-objekt renames fra `has` til `check`. Kunne evt brukt `get`, men siden disse sjekker ting synes jeg det passet best selv om de returnerer noe.