### PR TITLE
Use getListObject in norg cache overordnet enhet

### DIFF
--- a/src/main/kotlin/no/nav/syfo/client/norg/NorgClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/norg/NorgClient.kt
@@ -25,9 +25,9 @@ class NorgClient(
         enhet: Enhet,
     ): List<NorgEnhet> {
         val cacheKey = "$NORG_OVERORDNEDE_ENHETER_CACHE_KEY-$enhet"
-        val cachedEnheter = redisStore.getObject<List<NorgEnhet>>(key = cacheKey)
+        val cachedEnheter = redisStore.getListObject<NorgEnhet>(key = cacheKey)
 
-        return if (cachedEnheter != null) {
+        return if (!cachedEnheter.isNullOrEmpty()) {
             cachedEnheter
         } else {
             getOverordnedeEnheter(


### PR DESCRIPTION
Otherwise we get an exception because LinkedHashMap cannot be cast to NorgEnhet.
This affects everyone who gets to the "regional tilgang" part of the geografisk access check, because then we need to get a list of overordnede enheter.
