### PR TITLE
Validate personident strings in brukere endpoint

### DIFF
--- a/src/main/kotlin/no/nav/syfo/domain/Personident.kt
+++ b/src/main/kotlin/no/nav/syfo/domain/Personident.kt
@@ -1,5 +1,7 @@
 package no.nav.syfo.domain
 
+import org.slf4j.LoggerFactory
+
 @JvmInline
 value class Personident(val value: String) {
     private val elevenDigits: Regex
@@ -11,3 +13,17 @@ value class Personident(val value: String) {
         }
     }
 }
+
+fun List<String>.removeInvalidPersonidenter(): List<String> {
+    return this.filter {
+        try {
+            Personident(it)
+            true
+        } catch (e: IllegalArgumentException) {
+            log.error("Received invalid personident: $it")
+            false
+        }
+    }
+}
+
+private val log = LoggerFactory.getLogger(Personident::class.java)

--- a/src/main/kotlin/no/nav/syfo/tilgang/TilgangService.kt
+++ b/src/main/kotlin/no/nav/syfo/tilgang/TilgangService.kt
@@ -11,6 +11,7 @@ import no.nav.syfo.client.norg.NorgClient
 import no.nav.syfo.client.pdl.*
 import no.nav.syfo.client.skjermedepersoner.SkjermedePersonerPipClient
 import no.nav.syfo.domain.Personident
+import no.nav.syfo.domain.removeInvalidPersonidenter
 import org.slf4j.LoggerFactory
 
 class TilgangService(
@@ -284,7 +285,7 @@ class TilgangService(
         personidenter: List<String>,
         appName: String,
     ): List<String> {
-        return personidenter.filter { personident ->
+        return personidenter.removeInvalidPersonidenter().filter { personident ->
             checkTilgangToPerson(
                 token = token,
                 personident = Personident(personident),


### PR DESCRIPTION
Remove Strings that are not valid Personidenter without failing.

Jeg vet ikke om dette er en greit måte å gjøre det på, man kunne f.eks. mappet om i samme slengen? Og det burde kanskje ikke leve i Personident-filen? Burde vi logge når noe feiler? 🤷‍♂️ 