### PR TITLE
IS: Add access policy for oppfolgingsplan-backend

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -37,56 +37,24 @@ spec:
     inbound:
       rules:
         - application: isaktivitetskrav
-          namespace: teamsykefravr
-          cluster: dev-gcp
         - application: isarbeidsuforhet
         - application: isbehandlerdialog
-          namespace: teamsykefravr
-          cluster: dev-gcp
         - application: isdialogmelding
-          namespace: teamsykefravr
-          cluster: dev-gcp
         - application: isdialogmote
-          namespace: teamsykefravr
-          cluster: dev-gcp
         - application: isdialogmotekandidat
-          namespace: teamsykefravr
-          cluster: dev-gcp
         - application: isfrisktilarbeid
         - application: ishuskelapp
-          namespace: teamsykefravr
-          cluster: dev-gcp
         - application: ismeroppfolging
         - application: isnarmesteleder
-          namespace: teamsykefravr
-          cluster: dev-gcp
         - application: isoppfolgingstilfelle
-          namespace: teamsykefravr
-          cluster: dev-gcp
         - application: ispengestopp
-          namespace: teamsykefravr
-          cluster: dev-gcp
         - application: ispersonoppgave
-          namespace: teamsykefravr
-          cluster: dev-gcp
         - application: fastlegerest
-          namespace: teamsykefravr
-          cluster: dev-gcp
         - application: finnfastlege
-          namespace: teamsykefravr
-          cluster: dev-gcp
         - application: syfobehandlendeenhet
-          namespace: teamsykefravr
-          cluster: dev-gcp
         - application: syfomodiaperson
-          namespace: teamsykefravr
-          cluster: dev-gcp
         - application: syfooversiktsrv
-          namespace: teamsykefravr
-          cluster: dev-gcp
         - application: syfoperson
-          namespace: teamsykefravr
-          cluster: dev-gcp
         - application: esyfovarsel
           namespace: team-esyfo
           cluster: dev-gcp
@@ -103,6 +71,8 @@ spec:
           namespace: team-esyfo
           cluster: dev-gcp
         - application: meroppfolging-backend
+          namespace: team-esyfo
+        - application: oppfolgingsplan-backend
           namespace: team-esyfo
         - application: spinnsyn-backend
           namespace: flex

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -37,56 +37,24 @@ spec:
     inbound:
       rules:
         - application: isaktivitetskrav
-          namespace: teamsykefravr
-          cluster: prod-gcp
         - application: isarbeidsuforhet
         - application: isbehandlerdialog
-          namespace: teamsykefravr
-          cluster: prod-gcp
         - application: isdialogmelding
-          namespace: teamsykefravr
-          cluster: prod-gcp
         - application: isdialogmote
-          namespace: teamsykefravr
-          cluster: prod-gcp
         - application: isdialogmotekandidat
-          namespace: teamsykefravr
-          cluster: prod-gcp
         - application: isfrisktilarbeid
         - application: ishuskelapp
-          namespace: teamsykefravr
-          cluster: prod-gcp
         - application: ismeroppfolging
         - application: isnarmesteleder
-          namespace: teamsykefravr
-          cluster: prod-gcp
         - application: isoppfolgingstilfelle
-          namespace: teamsykefravr
-          cluster: prod-gcp
         - application: ispengestopp
-          namespace: teamsykefravr
-          cluster: prod-gcp
         - application: ispersonoppgave
-          namespace: teamsykefravr
-          cluster: prod-gcp
         - application: fastlegerest
-          namespace: teamsykefravr
-          cluster: prod-gcp
         - application: finnfastlege
-          namespace: teamsykefravr
-          cluster: prod-gcp
         - application: syfobehandlendeenhet
-          namespace: teamsykefravr
-          cluster: prod-gcp
         - application: syfomodiaperson
-          namespace: teamsykefravr
-          cluster: prod-gcp
         - application: syfooversiktsrv
-          namespace: teamsykefravr
-          cluster: prod-gcp
         - application: syfoperson
-          namespace: teamsykefravr
-          cluster: prod-gcp
         - application: esyfovarsel
           namespace: team-esyfo
           cluster: prod-gcp
@@ -103,6 +71,8 @@ spec:
           namespace: team-esyfo
           cluster: prod-gcp
         - application: meroppfolging-backend
+          namespace: team-esyfo
+        - application: oppfolgingsplan-backend
           namespace: team-esyfo
         - application: spinnsyn-backend
           namespace: flex


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
- Legger til `oppfolgingsplan-backend` i inbound policy. Forespørsel fra esyfo.
- Har inntrykk av at man ikke trenger å spesifisere `namespace` og `cluster` for hver app. I alle fall ikke som ligger i samme `namespace` (?). Er det riktig? 😊
