### PR TITLE
IS-3241: Unngå å cache mangel på tilgang

### DIFF
--- a/src/main/kotlin/no/nav/syfo/App.kt
+++ b/src/main/kotlin/no/nav/syfo/App.kt
@@ -57,6 +57,7 @@ fun main() {
         baseUrl = environment.clients.graphApiUrl,
         relevantSyfoRoller = adRoller.toList(),
         valkeyStore = valkeyStore,
+        adRoller = adRoller,
     )
 
     val axsysClient = AxsysClient(

--- a/src/main/kotlin/no/nav/syfo/client/behandlendeenhet/BehandlendeEnhetClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/behandlendeenhet/BehandlendeEnhetClient.kt
@@ -61,7 +61,7 @@ class BehandlendeEnhetClient(
             valkeyStore.setObject(
                 key = cacheKey,
                 value = behandlendeEnhet,
-                expireSeconds = TWELVE_HOURS_IN_SECS
+                expireSeconds = ONE_HOUR_IN_SECS
             )
             behandlendeEnhet
         }
@@ -139,6 +139,6 @@ class BehandlendeEnhetClient(
         private val log = LoggerFactory.getLogger(BehandlendeEnhetClient::class.java)
 
         const val BEHANDLENDEENHET_CACHE_KEY = "behandlendeenhet"
-        const val TWELVE_HOURS_IN_SECS = 12 * 60 * 60L
+        const val ONE_HOUR_IN_SECS = 1 * 60 * 60L
     }
 }

--- a/src/main/kotlin/no/nav/syfo/client/graphapi/GraphApiClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/graphapi/GraphApiClient.kt
@@ -12,6 +12,7 @@ import no.nav.syfo.application.cache.ValkeyStore
 import no.nav.syfo.client.azuread.AzureAdClient
 import no.nav.syfo.client.httpClientProxy
 import no.nav.syfo.tilgang.AdRolle
+import no.nav.syfo.tilgang.AdRoller
 import no.nav.syfo.util.bearerHeader
 import no.nav.syfo.util.callIdArgument
 import org.slf4j.LoggerFactory
@@ -22,6 +23,7 @@ class GraphApiClient(
     private val relevantSyfoRoller: List<AdRolle>,
     private val httpClient: HttpClient = httpClientProxy(),
     private val valkeyStore: ValkeyStore,
+    private val adRoller: AdRoller,
 ) {
     suspend fun hasAccess(
         adRolle: AdRolle,
@@ -47,11 +49,13 @@ class GraphApiClient(
             cachedRoleList
         } else {
             getRoleListFromGraphApi(token, callId).also {
-                valkeyStore.setObject(
-                    key = cacheKey,
-                    value = it,
-                    expireSeconds = TWELVE_HOURS_IN_SECS,
-                )
+                if (isRoleInUserGroupList(it, adRoller.SYFO)) {
+                    valkeyStore.setObject(
+                        key = cacheKey,
+                        value = it,
+                        expireSeconds = TWELVE_HOURS_IN_SECS,
+                    )
+                }
             }
         }
     }

--- a/src/main/kotlin/no/nav/syfo/client/skjermedepersoner/SkjermedePersonerPipClient.kt
+++ b/src/main/kotlin/no/nav/syfo/client/skjermedepersoner/SkjermedePersonerPipClient.kt
@@ -53,7 +53,7 @@ class SkjermedePersonerPipClient(
         return if (cachedSkjerming != null) {
             cachedSkjerming
         } else {
-            val enheter = getSkjermingFromSkjermedePersoner(
+            val skjermet = getSkjermingFromSkjermedePersoner(
                 callId = callId,
                 personIdent = personIdent,
                 token = token,
@@ -61,10 +61,10 @@ class SkjermedePersonerPipClient(
 
             valkeyStore.setObject(
                 key = cacheKey,
-                value = enheter,
+                value = skjermet,
                 expireSeconds = TWELVE_HOURS_IN_SECS,
             )
-            enheter
+            skjermet
         }
     }
 

--- a/src/main/kotlin/no/nav/syfo/tilgang/TilgangService.kt
+++ b/src/main/kotlin/no/nav/syfo/tilgang/TilgangService.kt
@@ -50,11 +50,13 @@ class TilgangService(
                 callId = callId,
             )
         )
-        valkeyStore.setObject(
-            key = cacheKey,
-            value = tilgang,
-            expireSeconds = TWELVE_HOURS_IN_SECS
-        )
+        if (tilgang.erGodkjent) {
+            valkeyStore.setObject(
+                key = cacheKey,
+                value = tilgang,
+                expireSeconds = TWELVE_HOURS_IN_SECS
+            )
+        }
         return tilgang
     }
 
@@ -70,11 +72,13 @@ class TilgangService(
         val tilgang = Tilgang(
             erGodkjent = enheter.map { it.enhetId }.contains(enhet.id)
         )
-        valkeyStore.setObject(
-            key = cacheKey,
-            value = tilgang,
-            expireSeconds = TWELVE_HOURS_IN_SECS
-        )
+        if (tilgang.erGodkjent) {
+            valkeyStore.setObject(
+                key = cacheKey,
+                value = tilgang,
+                expireSeconds = TWELVE_HOURS_IN_SECS
+            )
+        }
         return tilgang
     }
 
@@ -291,12 +295,13 @@ class TilgangService(
         }
         val tilgang = Tilgang(erGodkjent = erGodkjent)
 
-        valkeyStore.setObject(
-            key = cacheKey,
-            value = tilgang,
-            expireSeconds = TWELVE_HOURS_IN_SECS
-        )
-
+        if (tilgang.erGodkjent) {
+            valkeyStore.setObject(
+                key = cacheKey,
+                value = tilgang,
+                expireSeconds = TWELVE_HOURS_IN_SECS
+            )
+        }
         return tilgang
     }
 

--- a/src/test/kotlin/no/nav/syfo/client/graphapi/GraphApiClientSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/client/graphapi/GraphApiClientSpek.kt
@@ -74,7 +74,7 @@ class GraphApiClientSpek : Spek({
                     )
                 }
             }
-            it("Denies syfo access and stores in cache") {
+            it("Denies syfo access and does not store in cache") {
                 val validToken = generateJWT(
                     audience = externalMockEnvironment.environment.azure.appClientId,
                     issuer = externalMockEnvironment.wellKnownInternalAzureAD.issuer,
@@ -97,7 +97,7 @@ class GraphApiClientSpek : Spek({
                 }
                 hasAccess shouldBeEqualTo false
                 verify(exactly = 1) { valkeyStore.get(key = eq(cacheKey)) }
-                verify(exactly = 1) {
+                verify(exactly = 0) {
                     valkeyStore.setObject<List<GraphApiGroup>>(
                         key = eq(cacheKey),
                         value = any(),

--- a/src/test/kotlin/no/nav/syfo/client/graphapi/GraphApiClientSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/client/graphapi/GraphApiClientSpek.kt
@@ -37,6 +37,7 @@ class GraphApiClientSpek : Spek({
         relevantSyfoRoller = adRoller.toList(),
         httpClient = mockHttpClient,
         valkeyStore = valkeyStore,
+        adRoller = adRoller,
     )
 
     describe("GraphApiClient") {

--- a/src/test/kotlin/no/nav/syfo/testhelper/TestApiModule.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/TestApiModule.kt
@@ -48,6 +48,7 @@ fun Application.testApiModule(
         relevantSyfoRoller = adRoller.toList(),
         httpClient = mockHttpClient,
         valkeyStore = valkeyStore,
+        adRoller = adRoller,
     )
 
     val axsysClient = AxsysClient(

--- a/src/test/kotlin/no/nav/syfo/tilgang/TilgangServicePersonSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/tilgang/TilgangServicePersonSpek.kt
@@ -110,7 +110,7 @@ class TilgangServicePersonSpek : Spek({
                             callId = callId,
                         )
                     }
-                    verifyCacheSet(exactly = 1, key = cacheKey, harTilgang = false)
+                    verifyCacheSet(exactly = 0, key = cacheKey, harTilgang = false)
                 }
 
                 it("Return access if veileder has SYFO access") {
@@ -236,7 +236,7 @@ class TilgangServicePersonSpek : Spek({
                             any(),
                         )
                     }
-                    verifyCacheSet(exactly = 1, key = cacheKey, harTilgang = false)
+                    verifyCacheSet(exactly = 0, key = cacheKey, harTilgang = false)
                 }
 
                 it("Return access if veileder doesn't have national access but has access to innbyggers enhet") {
@@ -518,7 +518,7 @@ class TilgangServicePersonSpek : Spek({
                             callId = callId
                         )
                     }
-                    verifyCacheSet(exactly = 1, key = cacheKey, harTilgang = false)
+                    verifyCacheSet(exactly = 0, key = cacheKey, harTilgang = false)
                 }
 
                 it("return godkjent access if person is skjermet and veileder has correct AdRolle") {
@@ -606,7 +606,7 @@ class TilgangServicePersonSpek : Spek({
                             callId = callId
                         )
                     }
-                    verifyCacheSet(exactly = 1, key = cacheKey, harTilgang = false)
+                    verifyCacheSet(exactly = 0, key = cacheKey, harTilgang = false)
                 }
 
                 it("Return no access if person is kode7 and veileder doesn't have correct AdRolle") {
@@ -641,7 +641,7 @@ class TilgangServicePersonSpek : Spek({
                             callId = callId
                         )
                     }
-                    verifyCacheSet(exactly = 1, key = cacheKey, harTilgang = false)
+                    verifyCacheSet(exactly = 0, key = cacheKey, harTilgang = false)
                 }
 
                 it("return godkjent access if person is kode6 and veileder has correct AdRolle") {

--- a/src/test/kotlin/no/nav/syfo/tilgang/TilgangServiceSpek.kt
+++ b/src/test/kotlin/no/nav/syfo/tilgang/TilgangServiceSpek.kt
@@ -46,15 +46,11 @@ class TilgangServiceSpek : Spek({
 
     fun verifyCacheSet(exactly: Int, key: String = "", harTilgang: Boolean = true) {
         verify(exactly = exactly) {
-            if (exactly == 0) {
-                valkeyStore.setObject<Any>(any(), any(), any())
-            } else {
-                valkeyStore.setObject(
-                    key = key,
-                    value = Tilgang(erGodkjent = harTilgang),
-                    expireSeconds = TWELVE_HOURS_IN_SECONDS
-                )
-            }
+            valkeyStore.setObject(
+                key = key,
+                value = Tilgang(erGodkjent = harTilgang),
+                expireSeconds = TWELVE_HOURS_IN_SECONDS
+            )
         }
     }
 
@@ -156,7 +152,7 @@ class TilgangServiceSpek : Spek({
 
                 verify(exactly = 1) { valkeyStore.getObject<Tilgang?>(key = cacheKey) }
                 coVerify(exactly = 1) { axsysClient.getEnheter(validToken, callId) }
-                verifyCacheSet(exactly = 1, key = cacheKey, harTilgang = false)
+                verifyCacheSet(exactly = 0, key = cacheKey, harTilgang = false)
             }
 
             it("return result from cache hit") {
@@ -208,8 +204,8 @@ class TilgangServiceSpek : Spek({
                 coVerify(exactly = 0) { skjermedePersonerPipClient.getIsSkjermetWithOboToken(any(), personident2, any()) }
                 coVerify(exactly = 0) { pdlClient.getPerson(any(), personident1) }
                 coVerify(exactly = 0) { pdlClient.getPerson(any(), personident2) }
-                verifyCacheSet(exactly = 1, key = cacheKey1, harTilgang = false)
-                verifyCacheSet(exactly = 1, key = cacheKey2, harTilgang = false)
+                verifyCacheSet(exactly = 0, key = cacheKey1, harTilgang = false)
+                verifyCacheSet(exactly = 0, key = cacheKey2, harTilgang = false)
             }
 
             it("remove skjermet innbygger when veileder is missing access") {
@@ -255,7 +251,7 @@ class TilgangServiceSpek : Spek({
                 coVerify(exactly = 2) { pdlClient.getPerson(callId, personident) }
                 coVerify(exactly = 1) { pdlClient.getPerson(callId, personidentSkjermet) }
                 verifyCacheSet(exactly = 1, key = cacheKeyAccess, harTilgang = true)
-                verifyCacheSet(exactly = 1, key = cacheKeySkjermet, harTilgang = false)
+                verifyCacheSet(exactly = 0, key = cacheKeySkjermet, harTilgang = false)
             }
 
             it("remove innbyggere when veileder is missing correct access") {
@@ -329,9 +325,9 @@ class TilgangServiceSpek : Spek({
                 coVerify(exactly = 1) { pdlClient.getPerson(any(), personidentSkjermet) }
                 coVerify(exactly = 2) { pdlClient.getPerson(callId, personidentGradert) }
                 verifyCacheSet(exactly = 1, key = cacheKeyAccess, harTilgang = true)
-                verifyCacheSet(exactly = 1, key = cacheKeySkjermet, harTilgang = false)
-                verifyCacheSet(exactly = 1, key = cacheKeyOtherEnhet, harTilgang = false)
-                verifyCacheSet(exactly = 1, key = cacheKeyGradert, harTilgang = false)
+                verifyCacheSet(exactly = 0, key = cacheKeySkjermet, harTilgang = false)
+                verifyCacheSet(exactly = 0, key = cacheKeyOtherEnhet, harTilgang = false)
+                verifyCacheSet(exactly = 0, key = cacheKeyGradert, harTilgang = false)
             }
 
             it("Remove invalid personidenter") {
@@ -406,7 +402,7 @@ class TilgangServiceSpek : Spek({
                 coVerify(exactly = 1) { norgClient.getNAVKontorForGT(callId, GeografiskTilknytning(GeografiskTilknytningType.BYDEL, UserConstants.ENHET_VEILEDER_GT)) }
                 coVerify(exactly = 0) { skjermedePersonerPipClient.getIsSkjermetWithOboToken(callId, validPersonident, validToken) }
                 coVerify(exactly = 1) { pdlClient.getPerson(callId, validPersonident) }
-                verifyCacheSet(exactly = 1, key = cacheKeyValidPersonident, harTilgang = false)
+                verifyCacheSet(exactly = 0, key = cacheKeyValidPersonident, harTilgang = false)
             }
         }
 


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Unngå å cache mangel på tilgang i en del tilfeller. 

Da vil veiledere som i utgangspunktet mangler tilgang slippe å vente til neste dag når tilgangen har blitt ordnet i det sentrale tilgangssystemet.

