### PR TITLE
IS-3291: Modify config readiness probe

### DIFF
--- a/.nais/naiserator-dev.yaml
+++ b/.nais/naiserator-dev.yaml
@@ -8,16 +8,24 @@ metadata:
 spec:
   image: {{ image }}
   port: 8080
+  startup:
+    path: /internal/is_ready
+    initialDelay: 10
+    periodSeconds: 2
+    timeout: 5
+    failureThreshold: 5
   liveness:
     path: /internal/is_alive
-    initialDelay: 30
+    initialDelay: 10
     timeout: 1
     periodSeconds: 10
     failureThreshold: 5
   readiness:
     path: /internal/is_ready
-    initialDelay: 30
+    initialDelay: 10
+    periodSeconds: 2
     timeout: 1
+    failureThreshold: 1
   resources:
     limits:
       memory: 1024Mi

--- a/.nais/naiserator-prod.yaml
+++ b/.nais/naiserator-prod.yaml
@@ -8,16 +8,24 @@ metadata:
 spec:
   image: {{ image }}
   port: 8080
+  startup:
+    path: /internal/is_ready
+    initialDelay: 10
+    periodSeconds: 2
+    timeout: 5
+    failureThreshold: 5
   liveness:
     path: /internal/is_alive
-    initialDelay: 30
+    initialDelay: 10
     timeout: 1
     periodSeconds: 10
     failureThreshold: 5
   readiness:
     path: /internal/is_ready
-    initialDelay: 30
+    initialDelay: 10
+    periodSeconds: 2
     timeout: 1
+    failureThreshold: 1
   resources:
     limits:
       memory: 1024Mi


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Blitt færre feil/timeouts ved kall til `istilgangskontroll` fra `syfooversiktsrv`, så tror vi er på sporet av løsningen her. Gjør noen flere tilpasninger av konfigurasjonen av readiness proben.

