### PR TITLE
IS-3348: Erstattet bruk av kotlin.test.asserts med JUnit

### DIFF
--- a/src/test/kotlin/no/nav/syfo/application/api/PodApiTest.kt
+++ b/src/test/kotlin/no/nav/syfo/application/api/PodApiTest.kt
@@ -6,12 +6,12 @@ import io.ktor.http.*
 import io.ktor.server.routing.*
 import io.ktor.server.testing.*
 import no.nav.syfo.application.ApplicationState
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertNotNull
-import kotlin.test.assertTrue
 
 class PodApiTest {
 

--- a/src/test/kotlin/no/nav/syfo/audit/AuditLoggerTest.kt
+++ b/src/test/kotlin/no/nav/syfo/audit/AuditLoggerTest.kt
@@ -1,10 +1,10 @@
 package no.nav.syfo.audit
 
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertTrue
 
 class AuditLoggerTest {
 

--- a/src/test/kotlin/no/nav/syfo/client/graphapi/GraphApiClientTest.kt
+++ b/src/test/kotlin/no/nav/syfo/client/graphapi/GraphApiClientTest.kt
@@ -13,11 +13,11 @@ import no.nav.syfo.testhelper.ExternalMockEnvironment
 import no.nav.syfo.testhelper.UserConstants
 import no.nav.syfo.testhelper.generateJWT
 import no.nav.syfo.tilgang.AdRoller
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.util.*
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 class GraphApiClientTest {
     private val externalMockEnvironment = ExternalMockEnvironment()

--- a/src/test/kotlin/no/nav/syfo/client/norg/NorgClientTest.kt
+++ b/src/test/kotlin/no/nav/syfo/client/norg/NorgClientTest.kt
@@ -9,9 +9,9 @@ import no.nav.syfo.mocks.getMockHttpClient
 import no.nav.syfo.testhelper.ExternalMockEnvironment
 import no.nav.syfo.testhelper.UserConstants
 import no.nav.syfo.tilgang.Enhet
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import java.util.*
-import kotlin.test.assertTrue
 
 class NorgClientTest {
     private val externalMockEnvironment = ExternalMockEnvironment()

--- a/src/test/kotlin/no/nav/syfo/tilgang/TilgangApiTest.kt
+++ b/src/test/kotlin/no/nav/syfo/tilgang/TilgangApiTest.kt
@@ -12,12 +12,12 @@ import no.nav.syfo.testhelper.*
 import no.nav.syfo.util.NAV_CALL_ID_HEADER
 import no.nav.syfo.util.NAV_PERSONIDENT_HEADER
 import no.nav.syfo.util.configure
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 class TilgangApiTest {
     private val externalMockEnvironment = ExternalMockEnvironment()

--- a/src/test/kotlin/no/nav/syfo/tilgang/TilgangServiceTest.kt
+++ b/src/test/kotlin/no/nav/syfo/tilgang/TilgangServiceTest.kt
@@ -20,12 +20,12 @@ import no.nav.syfo.client.tilgangsmaskin.TilgangsmaskinClient
 import no.nav.syfo.domain.Personident
 import no.nav.syfo.testhelper.*
 import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Nested
 import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
-import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 
 class TilgangServiceTest {
     private val graphApiClient = mockk<GraphApiClient>(relaxed = true)


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈
Ved overgang til JUnit i tidligere [PR](https://github.com/navikt/istilgangskontroll/pull/139) så ble `kotlin.test.asserts` feilaktig lagt til i stedet for JUnit.

