### PR TITLE
IS-3841: Eget endepunkt for fastlegerest

### DIFF
--- a/src/main/kotlin/no/nav/syfo/tilgang/TilgangApi.kt
+++ b/src/main/kotlin/no/nav/syfo/tilgang/TilgangApi.kt
@@ -118,6 +118,47 @@ fun Route.registerTilgangApi(
             }
         }
 
+        get("/navident/fastlege/person") {
+            val callId = call.getCallId()
+            val requestedPersonident = call.getPersonidentHeader()
+                ?: throw IllegalArgumentException("Did not find a PersonIdent in request headers")
+            val token = call.getBearerHeader()
+                ?: throw IllegalArgumentException("Failed to check tilgang to fastlege/person for veileder. No Authorization header supplied")
+            if (token.isMissingNAVIdent()) {
+                throw IllegalArgumentException("Failed to check tilgang to fastlege/person for veileder. No NAV ident in token")
+            }
+            val appName = call.getAppname(preAuthorizedApps)
+                ?: throw IllegalArgumentException("Failed to check tilgang to fastlege/person for veileder. No consumer clientId was found")
+
+            val veileder = tilgangService.getVeileder(
+                token = token,
+                callId = callId,
+            )
+
+            if (!tilgangService.checkTilgangToFinnfastlege(veileder).erGodkjent) {
+                return@get call.respond(
+                    status = HttpStatusCode.Forbidden,
+                    message = Tilgang(erGodkjent = false)
+                )
+            }
+
+            val tilgang = tilgangService.checkTilgangToPerson(
+                personident = requestedPersonident,
+                veileder = veileder,
+                callId = callId,
+                appName = appName,
+            )
+
+            if (tilgang.erGodkjent) {
+                call.respond(tilgang)
+            } else {
+                call.respond(
+                    status = HttpStatusCode.Forbidden,
+                    message = tilgang
+                )
+            }
+        }
+
         get("/navident/person/papirsykmelding") {
             val callId = call.getCallId()
             val requestedPersonident = call.getPersonidentHeader()

--- a/src/main/kotlin/no/nav/syfo/tilgang/TilgangService.kt
+++ b/src/main/kotlin/no/nav/syfo/tilgang/TilgangService.kt
@@ -85,6 +85,31 @@ class TilgangService(
         }
     }
 
+    fun checkTilgangToFinnfastlege(veileder: Veileder): Tilgang {
+        val veilederident = veileder.veilederident
+        val cacheKey = "$TILGANG_TIL_FINNFASTLEGE_PREFIX$veilederident"
+        val cachedTilgang: Tilgang? = valkeyStore.getObject(key = cacheKey)
+
+        return if (cachedTilgang != null) {
+            cachedTilgang
+        } else {
+            Tilgang(
+                erGodkjent = veileder.hasFinnfastlegeTilgang(adRoller),
+            ).utvidMedTilganger(
+                veileder = veileder,
+                adRoller = adRoller,
+            ).also { tilgang ->
+                if (tilgang.erGodkjent) {
+                    valkeyStore.setObject(
+                        key = cacheKey,
+                        value = tilgang,
+                        expireSeconds = TWELVE_HOURS_IN_SECS
+                    )
+                }
+            }
+        }
+    }
+
     fun checkTilgangToEnhet(veileder: Veileder, enhet: Enhet): Tilgang {
         val veilederident = veileder.veilederident
         val cacheKey = "$TILGANG_TIL_ENHET_PREFIX$veilederident-$enhet"
@@ -482,6 +507,7 @@ class TilgangService(
         private val CHECK_PERSON_TILGANG_DISPATCHER = Dispatchers.IO.limitedParallelism(20)
 
         const val TILGANG_TIL_TJENESTEN_PREFIX = "tilgang-til-tjenesten-"
+        const val TILGANG_TIL_FINNFASTLEGE_PREFIX = "tilgang-til-finnfastlege-"
         const val TILGANG_TIL_ENHET_PREFIX = "tilgang-til-enhet-"
         const val TILGANG_TIL_PERSON_PREFIX = "tilgang-til-person-"
         const val TWELVE_HOURS_IN_SECS = 12 * 60 * 60L

--- a/src/test/kotlin/no/nav/syfo/testhelper/UserConstants.kt
+++ b/src/test/kotlin/no/nav/syfo/testhelper/UserConstants.kt
@@ -6,6 +6,7 @@ object UserConstants {
     const val VEILEDER_IDENT_NO_ENHET_ACCESS = "Z00000_no_enhet_access"
     const val VEILEDER_IDENT_NO_AZURE_AD_TOKEN = "Z00000_no_azure_ad_token"
     const val VEILEDER_IDENT_NO_PAPIRSYKMELDING_ACCESS = "Z00000_no_papirsykmelding_access"
+    const val VEILEDER_IDENT_NO_FINNFASTLEGE_ACCESS = "Z00000_no_finnfastlege_access"
 
     const val ENHET_INNBYGGER = "1233"
     const val ENHET_VEILEDER = "1234"

--- a/src/test/kotlin/no/nav/syfo/tilgang/TilgangApiTest.kt
+++ b/src/test/kotlin/no/nav/syfo/tilgang/TilgangApiTest.kt
@@ -47,6 +47,11 @@ class TilgangApiTest {
         issuer = externalMockEnvironment.wellKnownInternalAzureAD.issuer,
         navIdent = UserConstants.VEILEDER_IDENT_NO_PAPIRSYKMELDING_ACCESS,
     )
+    private val validTokenNoFinnfastlegeAccess = generateJWT(
+        audience = externalMockEnvironment.environment.azure.appClientId,
+        issuer = externalMockEnvironment.wellKnownInternalAzureAD.issuer,
+        navIdent = UserConstants.VEILEDER_IDENT_NO_FINNFASTLEGE_ACCESS,
+    )
 
     private val enhetWithoutTilgang = UserConstants.ENHET_VEILEDER_NO_ACCESS
     private val adRoller = AdRoller(externalMockEnvironment.environment)
@@ -272,6 +277,120 @@ class TilgangApiTest {
 
                 val response = client.get("$tilgangApiBasePath/navident/person") {
                     bearerAuth(validTokenNoEnhetAccess)
+                    header(NAV_PERSONIDENT_HEADER, UserConstants.PERSONIDENT_GRADERT)
+                    header(NAV_CALL_ID_HEADER, "123")
+                    header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                }
+
+                assertEquals(HttpStatusCode.Forbidden, response.status)
+                val tilgang = response.body<Tilgang>()
+                assertTrue(tilgang.erAvslatt)
+            }
+        }
+    }
+
+    @Nested
+    @DisplayName("Fastlege person access")
+    inner class FastlegePersonAccess {
+
+        @Test
+        fun `Allows access to person with FINNFASTLEGE access and correct local enhet`() {
+            testApplication {
+                val graphApiClientMock = spyk(graphApiClient)
+                coEvery { graphApiClientMock.getGrupperForVeilederOgCache(any(), any()) } returns listOf(
+                    createGruppeForRole(adRoller.FINNFASTLEGE),
+                    createGruppeForEnhet(ENHET_VEILEDER)
+                )
+                val client = setupApi(graphApiClientMock)
+
+                val response = client.get("$tilgangApiBasePath/navident/fastlege/person") {
+                    bearerAuth(validToken)
+                    header(NAV_PERSONIDENT_HEADER, UserConstants.PERSONIDENT)
+                    header(NAV_CALL_ID_HEADER, "123")
+                    header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                }
+
+                assertEquals(HttpStatusCode.OK, response.status)
+                val tilgang = response.body<Tilgang>()
+                assertTrue(tilgang.erGodkjent)
+            }
+        }
+
+        @Test
+        fun `Forbid access to person if no FINNFASTLEGE access`() {
+            testApplication {
+                val client = setupApi()
+
+                val response = client.get("$tilgangApiBasePath/navident/fastlege/person") {
+                    bearerAuth(validTokenNoFinnfastlegeAccess)
+                    header(NAV_PERSONIDENT_HEADER, UserConstants.PERSONIDENT)
+                    header(NAV_CALL_ID_HEADER, "123")
+                    header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                }
+
+                assertEquals(HttpStatusCode.Forbidden, response.status)
+                val tilgang = response.body<Tilgang>()
+                assertTrue(tilgang.erAvslatt)
+            }
+        }
+
+        @Test
+        fun `Forbid access to person if no geografisk access`() {
+            testApplication {
+                val graphApiClientMock = spyk(graphApiClient)
+                coEvery { graphApiClientMock.getGrupperForVeilederOgCache(any(), any()) } returns listOf(
+                    createGruppeForRole(adRoller.FINNFASTLEGE)
+                )
+                val client = setupApi(graphApiClientMock)
+
+                val response = client.get("$tilgangApiBasePath/navident/fastlege/person") {
+                    bearerAuth(validToken)
+                    header(NAV_PERSONIDENT_HEADER, UserConstants.PERSONIDENT)
+                    header(NAV_CALL_ID_HEADER, "123")
+                    header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                }
+
+                assertEquals(HttpStatusCode.Forbidden, response.status)
+                val tilgang = response.body<Tilgang>()
+                assertTrue(tilgang.erAvslatt)
+            }
+        }
+
+        @Test
+        fun `Forbid access to skjermet person without EGEN_ANSATT role`() {
+            testApplication {
+                val graphApiClientMock = spyk(graphApiClient)
+                coEvery { graphApiClientMock.getGrupperForVeilederOgCache(any(), any()) } returns listOf(
+                    createGruppeForRole(adRoller.FINNFASTLEGE),
+                    createGruppeForEnhet(ENHET_VEILEDER)
+                )
+                val client = setupApi(graphApiClientMock)
+
+                val response = client.get("$tilgangApiBasePath/navident/fastlege/person") {
+                    bearerAuth(validToken)
+                    header(NAV_PERSONIDENT_HEADER, UserConstants.PERSONIDENT_SKJERMET)
+                    header(NAV_CALL_ID_HEADER, "123")
+                    header(HttpHeaders.ContentType, ContentType.Application.Json.toString())
+                }
+
+                assertEquals(HttpStatusCode.Forbidden, response.status)
+                val tilgang = response.body<Tilgang>()
+                assertTrue(tilgang.erAvslatt)
+            }
+        }
+
+        @Test
+        fun `Forbid access to adressebeskyttet person without KODE6 or KODE7 role`() {
+            testApplication {
+                val graphApiClientMock = spyk(graphApiClient)
+                coEvery { graphApiClientMock.getGrupperForVeilederOgCache(any(), any()) } returns listOf(
+                    createGruppeForRole(adRoller.FINNFASTLEGE),
+                    createGruppeForEnhet(ENHET_VEILEDER)
+                )
+                val client = setupApi(graphApiClientMock)
+
+                val response = client.get("$tilgangApiBasePath/navident/fastlege/person") {
+                    bearerAuth(validToken)
                     header(NAV_PERSONIDENT_HEADER, UserConstants.PERSONIDENT_GRADERT)
                     header(NAV_CALL_ID_HEADER, "123")
                     header(HttpHeaders.ContentType, ContentType.Application.Json.toString())


### PR DESCRIPTION
### Hva har blitt lagt til✨🌈

Siden saksbehandlere skal kunne bruke Finnfastlege uten å ha tilgang til resten av Modia/Syfo må backend'en fastlegerest bruke et eget endepunkt i istilgangskontroll for person-tilgangen.

